### PR TITLE
Fix/beer2

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import 'pdfvuer'
+import './webpack-fix'
 import Vue from 'vue'
 import App from './App.vue'
 import store from './store'

--- a/src/webpack-fix.js
+++ b/src/webpack-fix.js
@@ -1,0 +1,28 @@
+/*
+ * This file is a copy of `https://github.com/mozilla/pdfjs-dist/blob/master/webpack.js`
+ *
+ * The original version uses an inline declaration of the worker-loader which
+ * overrides the configuration of the loader in our webpack config and does not
+ * put the resulting chunk in the js dir.
+ *
+ * This is unfortunate because the app store serves files based on the directory
+ * they sit in.
+ *
+ * In main.ts we first import module pdfvuer which imports the original webpack.js
+ * and sets the `pdfjs.GlobalWorkerOptions.workerPort` to a source file chunk that
+ * will be created using the unconfigured loader and written to `publicPath`.
+ *
+ * Then we import this fixed file that overwrites `pdfjs.GlobalWorkerOptions.workerPort`
+ * to a source file chunk that will be created using the loader configured in
+ * `vue.config.js` and written to `publicPath/js`.
+ */
+'use strict'
+
+var pdfjs = require('pdfjs-dist/build/pdf.js');
+var PdfjsWorker = require('pdfjs-dist/build/pdf.worker.js');
+
+if (typeof window !== 'undefined' && 'Worker' in window) {
+  pdfjs.GlobalWorkerOptions.workerPort = new PdfjsWorker();
+}
+
+module.exports = pdfjs;

--- a/vue.config.js
+++ b/vue.config.js
@@ -40,5 +40,14 @@ module.exports = {
         }
         return args
       })
+    config.module
+      .rule('worker')
+      .test(/\.worker\.js$/)
+      .use('worker-loader')
+      .loader('worker-loader')
+      .options({
+        name: 'js/[name].[hash].js'
+      })
+      .end()
   }
 }


### PR DESCRIPTION
smaller fix that first lets the faulty webpack config load the worker from the parent dir
but then overrides it with a version properly loaded from the js dir